### PR TITLE
Update dependency version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,9 @@ setup(
       'Programming Language :: Python :: 3.3',
     ],
     install_requires=[
-      'six',
+      'six>=1.6.1',
       'docopt',
-      'requests>=2.0.1',
+      'requests>=2.4.0',
       'urllib3',
     ],
     entry_points={'console_scripts': [


### PR DESCRIPTION
```python
from six.moves.configparser import ...
```

This [line of code](https://github.com/mtth/azkaban/blob/master/azkaban/util.py#L16) rely on six >= 1.6.1

```python
from requests.packages.urllib3 import disable_warnings
```

And this [line of code](https://github.com/mtth/azkaban/blob/master/azkaban/util.py#L13) rely on requests >= 2.4.0 (https://github.com/kennethreitz/requests/commit/811ee4eb5d9edba50a62b906420dec8e079532ae)