### PR TITLE
Support pipeline and queue level

### DIFF
--- a/azkaban/remote.py
+++ b/azkaban/remote.py
@@ -701,22 +701,19 @@ class Session(object):
       }[on_failure]
     except KeyError:
       raise ValueError('Invalid `on_failure` value: %r.' % (on_failure, ))
-    pipeline_level = 1
-    queue_level = 1
+    concurrency_level = None
     if isinstance(concurrent, bool):
       concurrent = 'concurrent' if concurrent else 'skip'
-    elif 'pipeline-' in concurrent:
-      concurrent, pipeline_level = concurrent.split('-')
-    elif 'queue-' in concurrent:
-      concurrent, queue_level = concurrent.split('-')
+    elif ':' in concurrent:
+      concurrent, concurrency_level = concurrent.split(':', 1)
     request_data = {
       'disabled': disabled,
       'concurrentOption': concurrent,
-      'pipelineLevel': pipeline_level,
-      'queueLevel': queue_level,
       'failureAction': failure_action,
       'notifyFailureFirst': 'true' if notify_early else 'false',
     }
+    if concurrency_level is not None:
+      request_data['%sLevel' % (concurrent, )] = concurrency_level
     if properties:
       request_data.update(dict(
         ('flowOverride[%s]' % (key, ), value)

--- a/azkaban/remote.py
+++ b/azkaban/remote.py
@@ -701,11 +701,19 @@ class Session(object):
       }[on_failure]
     except KeyError:
       raise ValueError('Invalid `on_failure` value: %r.' % (on_failure, ))
+    pipeline_level = 1
+    queue_level = 1
     if isinstance(concurrent, bool):
       concurrent = 'concurrent' if concurrent else 'skip'
+    elif 'pipeline-' in concurrent:
+      concurrent, pipeline_level = concurrent.split('-')
+    elif 'queue-' in concurrent:
+      concurrent, queue_level = concurrent.split('-')
     request_data = {
       'disabled': disabled,
       'concurrentOption': concurrent,
+      'pipelineLevel': pipeline_level,
+      'queueLevel': queue_level,
       'failureAction': failure_action,
       'notifyFailureFirst': 'true' if notify_early else 'false',
     }

--- a/azkaban/remote.py
+++ b/azkaban/remote.py
@@ -381,7 +381,13 @@ class Session(object):
     :param disabled_jobs: List of names of jobs not to run. Mutually exclusive
       with `jobs` parameter.
     :param concurrent: Run workflow concurrently with any previous executions.
-      Can either be a boolean or a valid concurrency option string.
+      Can either be a boolean or a valid concurrency option string. Available
+      string options: `'skip'`: (Do not run flow if it is already running),
+      `'pipeline:1'`: (Pipeline the flow, so the current execution will not be
+      overrun. Block job A until the previous flow job A has completed),
+      `'pipeline:2'`: (Pipeline the flow, so the current execution will not be
+      overrun. Block job A until the previous flow job A's children have
+      completed)
     :param properties: Dictionary that will override global properties in this
       execution of the workflow. This dictionary will be flattened similarly to
       how :class:`~azkaban.job.Job` options are handled.


### PR DESCRIPTION
This PR enable azkaban-cli to support pipeline and queue concurrency. Indeed Azkaban server don't support 'pipeline' and 'queue' concurrentOpion without their levels (pipelineLevel and queueLevel). Thus I decided that the python client should support arguments like: 
```
--mode pipeline-1
--mode pipeline-2
--mode queue-1
--mode queue-2
```