### PR TITLE
4 new methods

### DIFF
--- a/azkaban/__init__.py
+++ b/azkaban/__init__.py
@@ -4,7 +4,7 @@
 """Azkaban python library."""
 
 __all__ = ['Project', 'Job', 'PigJob']
-__version__ = '0.9.4'
+__version__ = '0.9.5'
 
 try:
   from .ext.pig import PigJob

--- a/azkaban/__init__.py
+++ b/azkaban/__init__.py
@@ -4,7 +4,7 @@
 """Azkaban python library."""
 
 __all__ = ['Project', 'Job', 'PigJob']
-__version__ = '0.9.2'
+__version__ = '0.9.4'
 
 try:
   from .ext.pig import PigJob

--- a/azkaban/remote.py
+++ b/azkaban/remote.py
@@ -590,14 +590,14 @@ class Session(object):
     )
     return res
 
-  def get_flows(self, name):
-    """Get list of flows corresponding to a project
+  def get_workflows(self, name):
+    """Get list of workflows corresponding to a project
 
     :param name: Project name
 
     """
     self._logger.debug(
-      'Fetching flows in project %s', name
+      'Fetching workflows in project %s', name
     )
     try:
       res = self._request(
@@ -609,7 +609,7 @@ class Session(object):
         },
       )
     except HTTPError:
-      raise AzkabanError('No flows found in project %s', name)
+      raise AzkabanError('No workflows found in project %s', name)
     else:
       try:
         return _extract_json(res)

--- a/azkaban/remote.py
+++ b/azkaban/remote.py
@@ -526,7 +526,6 @@ class Session(object):
       endpoint='schedule',
       params=request_data,
     ))
-    print self.url
     self._logger.info('Scheduled project %s workflow %s.', name, flow)
     return res
 

--- a/azkaban/remote.py
+++ b/azkaban/remote.py
@@ -590,6 +590,32 @@ class Session(object):
     )
     return res
 
+  def get_flows(self, name):
+    """Get list of flows corresponding to a project
+
+    :param name: Project name
+
+    """
+    self._logger.debug(
+      'Fetching flows in project %s', name
+    )
+    try:
+      res = self._request(
+        method='GET',
+        endpoint='manager',
+        params={
+          'ajax': 'fetchprojectflows',
+          'project': name,
+        },
+      )
+    except HTTPError:
+      raise AzkabanError('No flows found in project %s', name)
+    else:
+      try:
+        return _extract_json(res)
+      except ValueError:
+        raise AzkabanError('Project %s not found', name)
+
   def get_workflow_info(self, name, flow):
     """Get list of jobs corresponding to a workflow.
 


### PR DESCRIPTION
get_projects - Returns all projects on Azkaban
schedule_cron_workflows - Implements new cron scheduling for workflows per http://azkaban.github.io/azkaban/docs/latest/#api-flexible-schedule. Previous method is deprecated.
get_sla - Returns all SLAs of a workflow schedule
set_sla - Sets SLAs for a specified workflow schedule.