### PR TITLE
Lock urllib3 to 1.23 until requests can use urllib3 1.24 and any issues with urllib3 1.24 in azkabancli are resolved

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
       'six>=1.6.1',
       'docopt',
       'requests>=2.4.0',
-      'urllib3',
+      'urllib3==1.23',
     ],
     entry_points={'console_scripts': [
       'azkaban = azkaban.__main__:main',


### PR DESCRIPTION
On 2018-10-16, urllib3 released backwards incompatible changes that breaks against requests and I am seeing indications that it breaks with azkabancli as well. This is to lock to the working version of urllib3==1.23 until all bugs against urllib3==1.24 within azkabancli and requests are resolved.