### PR TITLE
Fix AzkabanError bug affecting python 2.6+

### DIFF
--- a/azkaban/util.py
+++ b/azkaban/util.py
@@ -32,7 +32,9 @@ class AzkabanError(Exception):
   """Base error class."""
 
   def __init__(self, message, *args):
-    super(AzkabanError, self).__init__(message % args if args else message)
+    message = message % args if args else message
+    super(AzkabanError, self).__init__(message)
+    self.message = message
 
 
 class Adapter(lg.LoggerAdapter):


### PR DESCRIPTION
Fixes issue #29: AttributeError: 'AzkabanError' object has no attribute 'message'.

Python's `Exception` doesn't have `message` since 2.6. Store it in a field so that calls of `AzkabanError.message` keep working.

To reproduce this in a test, I added this to `test_remote.py`:

```python
class TestRefresh(_TestSession):

  @raises(AzkabanError)
  def test_refresh_wrong_password(self):
    self.session._refresh('foo')
```

It's more of a side-effect than a specific test, but that reaches a line where `AzkabanError.message` is called.

Before the fix:

```
nosetests test/test_remote.py:TestRefresh
E
======================================================================
ERROR: test_remote.TestRefresh.test_refresh_wrong_password
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/JuhoAutio/.pyenv/versions/3.7.0/lib/python3.7/site-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/Users/JuhoAutio/.pyenv/versions/3.7.0/lib/python3.7/site-packages/nose/tools/nontrivial.py", line 60, in newfunc
    func(*arg, **kw)
  File "/Users/JuhoAutio/ideaprojects/AzkabanCli/azkaban/test/test_remote.py", line 616, in test_refresh_wrong_password
    self.session._refresh('foo')
  File "/Users/JuhoAutio/ideaprojects/AzkabanCli/azkaban/azkaban/remote.py", line 763, in _refresh
    if not 'Incorrect Login.' in err.message:
AttributeError: 'AzkabanError' object has no attribute 'message'
```

After fix:

```
nosetests test/test_remote.py:TestRefresh
.
----------------------------------------------------------------------
Ran 1 test in 0.024s

OK
```

Unless there was something random in play, this also fixes one of the existing integration test errors (when running with python 3.7.0).