### PR TITLE
Address errors when attempting to create project while deploying build. (`-cp` options)

### DIFF
--- a/azkaban/__init__.py
+++ b/azkaban/__init__.py
@@ -4,7 +4,7 @@
 """Azkaban python library."""
 
 __all__ = ['Project', 'Job', 'PigJob']
-__version__ = '0.9.8'
+__version__ = '0.9.9'
 
 try:
   from .ext.pig import PigJob

--- a/azkaban/__main__.py
+++ b/azkaban/__main__.py
@@ -328,7 +328,9 @@ def _upload_zip(session, name, path, create=False, archive_name=None):
       if e.response.status_code == 410:
           session.create_project(name, name)
       elif e.response.status_code == 400:
-          raise AzkabanError("Failed to upload project. Verify that Project is not locked, exists and your users has write permission. HTTPError: {0}".format(e.response.status_code))
+          raise AzkabanError("Failed to upload project. Verify that Project is not locked, exists and your user has write permission. HTTPError: {0}".format(e.response.status_code))
+      elif e.response.status_code == 401:
+          raise AzkabanError("Failed to upload project due to not being authorized. Verify that your user has write permission. HTTPError: {0}".format(e.response.status_code))
       else:
           raise e
     else:

--- a/azkaban/__main__.py
+++ b/azkaban/__main__.py
@@ -324,6 +324,8 @@ def _upload_zip(session, name, path, create=False, archive_name=None):
         session.create_project(name, name)
       else:
         raise err
+    except HTTPError as e:
+      session.create_project(name, name)
     else:
       return res
 

--- a/azkaban/__main__.py
+++ b/azkaban/__main__.py
@@ -325,7 +325,10 @@ def _upload_zip(session, name, path, create=False, archive_name=None):
       else:
         raise err
     except HTTPError as e:
-      session.create_project(name, name)
+      if e.response.status_code == 410:
+          session.create_project(name, name)
+      else:
+          raise e
     else:
       return res
 

--- a/azkaban/__main__.py
+++ b/azkaban/__main__.py
@@ -327,6 +327,8 @@ def _upload_zip(session, name, path, create=False, archive_name=None):
     except HTTPError as e:
       if e.response.status_code == 410:
           session.create_project(name, name)
+      elif e.response.status_code == 400:
+          raise AzkabanError("Failed to upload project. Verify that Project is not locked, exists and your users has write permission. HTTPError: {0}".format(e.response.status_code))
       else:
           raise e
     else:


### PR DESCRIPTION
The newer versions of Azkaban throw a different error when they attempting to post a project that does not exit.

Previously it threw a AzkabanError, and it now throws a HTTPError. This results in the existing logic in handling the upload of a non-existent project to start failing on the newer versions of Azkaban.

To address this, I have made the following changes. The current code looks like this:

```
  while True:
    try:
      res = session.upload_project(
        name=name,
        path=path,
        archive_name=archive_name,
        callback=_callback,
      )
    except AzkabanError as err:
      if create and str(err).endswith("doesn't exist."):
        session.create_project(name, name)
      else:
        raise err
    else:
      return res
```

To address the new scenario, I added an additional `except` check.

```
  while True:
    try:
      res = session.upload_project(
        name=name,
        path=path,
        archive_name=archive_name,
        callback=_callback,
      )
    except AzkabanError as err:
      if create and str(err).endswith("doesn't exist."):
        session.create_project(name, name)
      else:
        raise err
    except HTTPError as e:
      if e.response.status_code == 410:
          session.create_project(name, name)
      elif e.response.status_code == 400:
          raise AzkabanError("Failed to upload project. Verify that Project is not locked, exists and your user has write permission. HTTPError: {0}".format(e.response.status_code))
      elif e.response.status_code == 401:
          raise AzkabanError("Failed to upload project due to not being authorized. Verify that your user has write permission. HTTPError: {0}".format(e.response.status_code))
      else:
          raise e
    else:
      return res
```

This resolves the issue and allows the `azkaban build -cp <project_file> -a <alias>` options to work once again.