### PR TITLE
to support nested job of  'disabled_jobs' and 'jobs' options

### DIFF
--- a/azkaban/remote.py
+++ b/azkaban/remote.py
@@ -20,6 +20,7 @@ from warnings import warn
 import logging as lg
 import requests as rq
 import re
+import json
 
 
 _logger = lg.getLogger(__name__)
@@ -797,7 +798,7 @@ class Session(object):
       if not disabled_jobs:
         disabled = '[]'
       else:
-        disabled = '[%s]' % (','.join('"%s"' % (n, ) for n in disabled_jobs), )
+        disabled = json.dumps(disabled_jobs)
     else:
       all_names = set(
         n['id']
@@ -811,10 +812,7 @@ class Session(object):
           (flow, ', '.join(missing_names))
         )
       else:
-        disabled = (
-          '[%s]'
-          % (','.join('"%s"' % (n, ) for n in all_names - run_names), )
-        )
+        disabled = json.dumps(all_names - run_names) 
     try:
       failure_action = {
         'finish': 'finishCurrent',


### PR DESCRIPTION
Currently, 'disabled_jobs' is submited as a list of string, as azkaban document explained. But we can't submit workflow execution with a nested job disabled. When I dive into source code of Azkaban project, I find that the restful API of Azkaban can support 'disabled' of nested jobs. The complete form of disbabled_jobs should like this,

```
[
     "job1",
     "job2",
     {
        "id":"nested_workflow_1",
        "children":[
           "job-a",
           "job-b",
           {
               "id":"nested_nested_workflow_2",
               "children":[...]
           }
        ]
    }
]
```
In fact, it can be nested many times!

azkaban source code reference: 
https://github.com/azkaban/azkaban/blob/master/azkaban-common/src/main/java/azkaban/executor/DisabledJob.java